### PR TITLE
Increase max session duration

### DIFF
--- a/modules/aws_iam_role/tf_module/main.tf
+++ b/modules/aws_iam_role/tf_module/main.tf
@@ -48,6 +48,7 @@ data "aws_iam_policy_document" "iam_trusts" {
 resource "aws_iam_role" "role" {
   assume_role_policy = data.aws_iam_policy_document.iam_trusts.json
   name               = "${var.env_name}-${var.layer_name}-${var.module_name}"
+  max_session_duration = 14400
 }
 
 resource "aws_iam_role_policy_attachment" "vanilla_role_attachment" {


### PR DESCRIPTION
# Description
Increase iam role creation to set max session duration to 4 hours to scope timeouts for long-running flyte workflow jobs

This is a [terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) attribute which can take on the value of 1 - 12 hours. The default is 1 hr.

It could be worthwhile to make this configurable since opta [does not](https://docs.opta.dev/reference/aws/modules/aws-iam-role/) but will wait until customer requests arise to inform that decision