### PR TITLE
Make sure metrics-server runs on port 8443

### DIFF
--- a/modules/aws_k8s_base/tf_module/metrics_server.tf
+++ b/modules/aws_k8s_base/tf_module/metrics_server.tf
@@ -17,7 +17,10 @@ resource "helm_release" "metrics_server" {
       apiService : {
         create : true
       }
-      args : ["--metric-resolution=15s"]
+      args : [
+        "--secure-port=8443",
+        "--metric-resolution=15s"
+      ]
     })
   ]
 }

--- a/modules/aws_k8s_base/tf_module/metrics_server.tf
+++ b/modules/aws_k8s_base/tf_module/metrics_server.tf
@@ -17,10 +17,7 @@ resource "helm_release" "metrics_server" {
       apiService : {
         create : true
       }
-      args : [
-        "--secure-port=8443",
-        "--metric-resolution=15s"
-      ]
+      extraArgs: ["--metric-resolution=15s"]
     })
   ]
 }

--- a/modules/aws_k8s_base/tf_module/metrics_server.tf
+++ b/modules/aws_k8s_base/tf_module/metrics_server.tf
@@ -17,7 +17,7 @@ resource "helm_release" "metrics_server" {
       apiService : {
         create : true
       }
-      extraArgs: ["--metric-resolution=15s"]
+      extraArgs : ["--metric-resolution=15s"]
     })
   ]
 }


### PR DESCRIPTION
# Description
The bitnami chart that we're using for `metrics-server` expects the underlying daemon to be listening on port 8443.  When we made [this change](https://github.com/unionai/opta/commit/12cb30e32508edbbe98250cabe8976c5df5e662b), we inadvertently caused `metrics-server` to start listening on the default port of `443`.  As for why, see the [bitnami chart](https://github.com/bitnami/charts/blob/main/bitnami/metrics-server/templates/deployment.yaml#L88-L96).  Basically, specifying `args` will override all args including the default args that tell `metrics-server` which port to run on.

Looks like using `extraArgs` is safer here.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
I have not tested this change, but reading through the code I'm confident this should fix it.
