### PR TITLE
Do not override default KMS key

### DIFF
--- a/modules/aws_base/tf_module/ebs.tf
+++ b/modules/aws_base/tf_module/ebs.tf
@@ -1,7 +1,3 @@
-resource "aws_ebs_default_kms_key" "default" {
-  key_arn = aws_kms_key.key.arn
-}
-
 resource "aws_ebs_encryption_by_default" "default" {
   enabled = true
 }


### PR DESCRIPTION
# Description
Right now Opta is creating a KMS key as part of the `aws_base` module, and setting the account-wide default EBS encryption key to this key.  This is problematic for a few reasons:
- This behavior may be undesirable for some users who do not expect or want Opta to override the account-wide default.
- If you are using Opta to manage multiple "environments" in the same account, each instance of `aws_base` will overwrite the default key every time.  This results in a permadiff of sorts.

There are a number of ways we could handle this:
- Easy & Safe: Do not override the default KMS key
- Ideal & more work: Put this behind a variable that allows the user to override this behavior.  This would allow us to maintain backwards compatibility for other Opta users, but require that we go and set this variable everywhere that we do not want Opta managing this key.

I think for our use case with this fork, we should take the easier/safer approach and not manage the account-wide default key at all.  This key is [referenced directly throughout Opta](https://github.com/search?q=repo%3Aunionai%2Fopta%20kms_account_key&type=code), and I do not believe we will cause any issues by not overriding the default EBS encryption key.  EKS clusters will still use the correct key for each Opta environment for persistent volumes and secrets encryption.  EC2 instances will still use the default key for encrypted EBS volumes.

For any new Opta managed environments, the default key will remain set to the default AWS managed key.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested by running two `aws_base` instances in the same account and making sure the "permadiff" goes away.
