### PR TITLE
Update GHA runner OS - ubuntu 18.04 is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   no-pdb:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: No PDB
@@ -19,7 +19,7 @@ jobs:
           cd scripts
           ./no_pdb.sh
   shell-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install shellcheck
@@ -30,7 +30,7 @@ jobs:
         run: |
           shellcheck **/*.sh
   shell-fmt:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
@@ -43,7 +43,7 @@ jobs:
         run: |
           shfmt -d ./
   python-lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
@@ -62,7 +62,7 @@ jobs:
           ./scripts/lint.py
 
   security:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
@@ -77,7 +77,7 @@ jobs:
       - name: Security
         run: make security_tests
   terraform_format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Pin terraform version
@@ -91,7 +91,7 @@ jobs:
           terraform fmt -recursive -check ./modules
 
   python:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Pin terraform version

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   package-linux:
     # needs: create-destroy-tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       VERSION: ${{ github.event.inputs.version }}
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   package-centos:
     # needs: create-destroy-tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       VERSION: ${{ github.event.inputs.version }}
     container:

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -7,7 +7,7 @@ on:
         required: true
 jobs:
   update_s3_file:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       VERSION: ${{ github.event.inputs.version }}
     steps:


### PR DESCRIPTION
# Description
Patch for: https://github.com/actions/runner-images/issues/6002

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
