### PR TITLE
Create VPC Endpoint Gateway for S3

### DIFF
--- a/modules/aws_base/tf_module/s3_gateway.tf
+++ b/modules/aws_base/tf_module/s3_gateway.tf
@@ -1,4 +1,5 @@
 resource "aws_vpc_endpoint" "s3" {
+  count             = local.create_vpc ? 1 : 0
   vpc_id            = local.vpc_id
   service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
   vpc_endpoint_type = "Gateway"

--- a/modules/aws_base/tf_module/s3_gateway.tf
+++ b/modules/aws_base/tf_module/s3_gateway.tf
@@ -1,0 +1,15 @@
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = local.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_endpoint_type = "Gateway"
+  tags = {
+    Name      = "opta-${var.layer_name}-s3-gateway"
+    terraform = "true"
+  }
+}
+
+resource "aws_vpc_endpoint_route_table_association" "s3" {
+    count  = local.create_vpc ? length(var.private_ipv4_cidr_blocks) : 0
+    vpc_endpoint_id = aws_vpc_endpoint.s3.id
+    route_table_id = aws_route_table.private_route_tables[count.index].id
+}

--- a/modules/aws_base/tf_module/s3_gateway.tf
+++ b/modules/aws_base/tf_module/s3_gateway.tf
@@ -9,7 +9,7 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "s3" {
-    count  = local.create_vpc ? length(var.private_ipv4_cidr_blocks) : 0
-    vpc_endpoint_id = aws_vpc_endpoint.s3.id
-    route_table_id = aws_route_table.private_route_tables[count.index].id
+  count           = local.create_vpc ? length(var.private_ipv4_cidr_blocks) : 0
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+  route_table_id  = aws_route_table.private_route_tables[count.index].id
 }


### PR DESCRIPTION
# Description
Right now any traffic to S3 in the same region will traverse over a NAT gateway for instances inside the private subnets.  This can be problematic for users with large S3 workloads, as you'll end up paying for bandwidth on the NAT gateway.

[A VPC gateway for S3](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html) is the best solution here.  These wire up much like a NAT gateway.  A route is added to a subnet's route table and sends all S3-destined traffic to the S3 gateway endpoint instead of the NAT gateway.  Most importantly, users do not pay for bandwidth over this S3 gateway endpoint.

In my opinion, this should be the default behavior for all VPCs.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Yes.  I tested this by applying the change to an existing environment and manually inspected the end state.
