### PR TITLE
Fix issue around counts with VPC Endpoints

### DIFF
--- a/modules/aws_base/tf_module/s3_gateway.tf
+++ b/modules/aws_base/tf_module/s3_gateway.tf
@@ -11,6 +11,6 @@ resource "aws_vpc_endpoint" "s3" {
 
 resource "aws_vpc_endpoint_route_table_association" "s3" {
   count           = local.create_vpc ? length(var.private_ipv4_cidr_blocks) : 0
-  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+  vpc_endpoint_id = aws_vpc_endpoint[0].s3.id
   route_table_id  = aws_route_table.private_route_tables[count.index].id
 }

--- a/modules/aws_base/tf_module/s3_gateway.tf
+++ b/modules/aws_base/tf_module/s3_gateway.tf
@@ -11,6 +11,6 @@ resource "aws_vpc_endpoint" "s3" {
 
 resource "aws_vpc_endpoint_route_table_association" "s3" {
   count           = local.create_vpc ? length(var.private_ipv4_cidr_blocks) : 0
-  vpc_endpoint_id = aws_vpc_endpoint[0].s3.id
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
   route_table_id  = aws_route_table.private_route_tables[count.index].id
 }


### PR DESCRIPTION
# Description
Oops, when we added a `count` to guard against creating VPC Endpoints, I failed to update the reference in `aws_vpc_endpoint_route_table_association`.  This fixes the error:

```
ERROR: ╷
│ Error: Missing resource instance key
│ 
│   on ../../../../../../.opta/modules/aws_base/tf_module/s3_gateway.tf line 14, in resource "aws_vpc_endpoint_route_table_association" "s3":
│   14:   vpc_endpoint_id = aws_vpc_endpoint.s3.id
│ 
│ Because aws_vpc_endpoint.s3 has "count" set, its attributes must be
│ accessed on specific instances.
│ 
│ For example, to correlate with indices of a referring resource, use:
│     aws_vpc_endpoint.s3[count.index]
```

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup
