### PR TITLE
Add ASG tags to scale up from 0

### DIFF
--- a/modules/aws_nodegroup/aws-nodegroup.json
+++ b/modules/aws_nodegroup/aws-nodegroup.json
@@ -3,9 +3,9 @@
   "description": "Deploys a kubernetes app",
   "type": "object",
   "properties": {
-    "additional_asg_tags": {
+    "autoscaling_tags": {
       "type": "object",
-      "description": "additional tags for the autoscaling group",
+      "description": "tags for the underlying autoscaling group",
       "default": {}
     },
     "labels": {

--- a/modules/aws_nodegroup/aws-nodegroup.json
+++ b/modules/aws_nodegroup/aws-nodegroup.json
@@ -3,6 +3,11 @@
   "description": "Deploys a kubernetes app",
   "type": "object",
   "properties": {
+    "additional_asg_tags": {
+      "type": "object",
+      "description": "additional tags for the autoscaling group",
+      "default": {}
+    },
     "labels": {
       "type": "object",
       "description": "labels for the kubernetes nodes",

--- a/modules/aws_nodegroup/aws-nodegroup.yaml
+++ b/modules/aws_nodegroup/aws-nodegroup.yaml
@@ -18,6 +18,11 @@ inputs:
     validator: map(str(), str(), required=False)
     description: labels for the kubernetes nodes
     default: {}
+  - name: additional_asg_tags
+    user_facing: true
+    validator: map(str(), str(), required=False)
+    description: additional tags for the autoscaling group
+    default: {}
   - name: max_nodes
     user_facing: true
     validator: any(str(), int(), required=False)

--- a/modules/aws_nodegroup/aws-nodegroup.yaml
+++ b/modules/aws_nodegroup/aws-nodegroup.yaml
@@ -18,10 +18,10 @@ inputs:
     validator: map(str(), str(), required=False)
     description: labels for the kubernetes nodes
     default: {}
-  - name: additional_asg_tags
+  - name: autoscaling_tags
     user_facing: true
     validator: map(str(), str(), required=False)
-    description: additional tags for the autoscaling group
+    description: tags for the underlying autoscaling group
     default: {}
   - name: max_nodes
     user_facing: true

--- a/modules/aws_nodegroup/tf_module/main.tf
+++ b/modules/aws_nodegroup/tf_module/main.tf
@@ -86,7 +86,10 @@ resource "aws_eks_node_group" "node_group" {
     create_before_destroy = true
   }
 
-  tags = {
-    terraform = "true"
-  }
+  tags = merge(
+    {
+      terraform = "true"
+    },
+    var.additional_asg_tags
+  )
 }

--- a/modules/aws_nodegroup/tf_module/variables.tf
+++ b/modules/aws_nodegroup/tf_module/variables.tf
@@ -74,3 +74,8 @@ variable "use_gpu" {
   type    = bool
   default = false
 }
+
+variable "additional_asg_tags" {
+  type    = map(string)
+  default = {}
+}

--- a/modules/aws_nodegroup/tf_module/variables.tf
+++ b/modules/aws_nodegroup/tf_module/variables.tf
@@ -75,7 +75,7 @@ variable "use_gpu" {
   default = false
 }
 
-variable "additional_asg_tags" {
+variable "autoscaling_tags" {
   type    = map(string)
   default = {}
 }


### PR DESCRIPTION
# Description
Per [cluster autoscaler guidance](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup) we need to apply tags to ASGs to properly scale up from 0 nodes.

In particular
> The following is only required if scaling up from 0 nodes. The Cluster Autoscaler will require the label tag on the ASG should a deployment have a NodeSelector, else no scaling will occur as the Cluster Autoscaler does not realise the ASG has that particular label. The tag is of the format k8s.io/cluster-autoscaler/node-template/label/<label-name>: <label-value> is the name of the label and the value of each tag specifies the label value.

And
> The following is only required if scaling up from 0 nodes. The Cluster Autoscaler will require the taint tag on the ASG, else tainted nodes may get spun up that cannot actually have the pending pods run on it. The tag is of the format k8s.io/cluster-autoscaler/node-template/taint/<taint-name>:<taint-value:taint-effect> is the name of the taint and the value of each tag specifies the taint value and effect with the format <taint-value>:<taint-effect>.

This change adds an optional `autoscaling_tags` var to the `aws_nodegroup` module. This directly creates ASG tag resources, as EKS managed node group tags are [not propagated to the ASG](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1886). We may also consider auto-applying taint tags based on the `taints` var, but this change would still be needed for node selectors.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Verified that locally running opta with a config including
```
modules:
  ...
  - type: aws-nodegroup
    ...
    autoscaling_tags:
      k8s.io/cluster-autoscaler/node-template/label/foo: bar
      k8s.io/cluster-autoscaler/node-template/taint/flyte.org/node-role: worker:NoSchedule
```

Generates a plan with changes like
```
  # module.nodegroup1.aws_autoscaling_group_tag.node_group["k8s.io/cluster-autoscaler/node-template/label/foo"] will be created
  + resource "aws_autoscaling_group_tag" "node_group" {
      + autoscaling_group_name = "eks-opta-my-cluster-nodegroup1-90f7242cf7829c71-eec3950a-8c39-d299-4d03-e64fed3c1d7a"
      + id                     = (known after apply)

      + tag {
          + key                 = "k8s.io/cluster-autoscaler/node-template/label/foo"
          + propagate_at_launch = false
          + value               = "bar"
        }
    }

  # module.nodegroup1.aws_autoscaling_group_tag.node_group["k8s.io/cluster-autoscaler/node-template/taint/flyte.org/node-role"] will be created
  + resource "aws_autoscaling_group_tag" "node_group" {
      + autoscaling_group_name = "eks-opta-my-cluster-nodegroup1-90f7242cf7829c71-eec3950a-8c39-d299-4d03-e64fed3c1d7a"
      + id                     = (known after apply)

      + tag {
          + key                 = "k8s.io/cluster-autoscaler/node-template/taint/flyte.org/node-role"
          + propagate_at_launch = false
          + value               = "worker:NoSchedule"
        }
    }
```
