### PR TITLE
Explicitly enable ACLs for aws_base log bucket

### DIFF
--- a/modules/aws_base/tf_module/log_bucket.tf
+++ b/modules/aws_base/tf_module/log_bucket.tf
@@ -23,9 +23,21 @@ resource "aws_s3_bucket_public_access_block" "log_bucket" {
 
 }
 
+resource "aws_s3_bucket_ownership_controls" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "log_bucket" {
   bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.log_bucket
+  ]
 }
 
 resource "aws_s3_bucket_versioning" "log_bucket" {


### PR DESCRIPTION
# Description
AWS has now disabled ACLs by default for all new buckets per this [blog](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/) post. As such, to use the required ACLs with the logging bucket, ACLs will need to be explicitly enabled as indicated [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html). This PR explicitly enables ACLs for the logging bucket by creating the [`aws_s3_bucket_ownership_controls`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) resource for setting object ownership to `BucketOwnerPreferred` as opposed to the now default `BucketOwnerEnforced`.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Tested by running the following opta config from scratch:
```
name: test # ENV_NAME
org_name: jeev-aws-test # ORG_NAME
providers:
  aws:
    region: us-east-2 # REGION
    account_id: "xxxxxxxxxxxx" # ACCOUNT_ID
modules:
  - type: base
```
