### PR TITLE
Update nvidia-device-plugin helm chart, and fix affinities and tolera…

### DIFF
--- a/modules/aws_k8s_base/tf_module/nvidia_daemonset.tf
+++ b/modules/aws_k8s_base/tf_module/nvidia_daemonset.tf
@@ -1,15 +1,35 @@
 resource "helm_release" "nvidia_daemonset" {
+  namespace       = "kube-system"
   chart           = "nvidia-device-plugin"
   name            = "nvidia-device-plugin"
   repository      = "https://nvidia.github.io/k8s-device-plugin"
-  version         = "0.9.0"
+  version         = "0.14.0"
   atomic          = true
   cleanup_on_fail = true
   values = [
     yamlencode({
-      nodeSelector : {
-        gpu : "true"
-      }
+      affinity : {
+        nodeAffinity : {
+          requiredDuringSchedulingIgnoredDuringExecution : {
+            nodeSelectorTerms : [
+              {
+                matchExpressions : [
+                  {
+                    key : "ami_type"
+                    operator : "In"
+                    values : ["AL2_x86_64_GPU"]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      tolerations : [
+        {
+          operator : "Exists"
+        }
+      ]
     })
   ]
 }

--- a/modules/aws_nodegroup/tf_module/variables.tf
+++ b/modules/aws_nodegroup/tf_module/variables.tf
@@ -5,11 +5,7 @@ data "aws_eks_cluster" "main" {
 }
 
 locals {
-  default_labels = var.ami_type == "AL2_x86_64_GPU" ? {
-    node_group_name = "opta-${var.layer_name}-${var.module_name}"
-    ami_type        = var.ami_type
-    gpu             = true
-    } : {
+  default_labels = {
     node_group_name = "opta-${var.layer_name}-${var.module_name}"
     ami_type        = var.ami_type
   }


### PR DESCRIPTION
…tions

# Description
- Update `nvidia-device-plugin` helm chart to the latest version
- Use node affinity instead of nodeselector, and leverage `ami_type` label instead of adding another label
- Tolerate all taints since this is a critical pod.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Smoke tested.
