### PR TITLE
Add support for inferring commonly used variables in aws_iam_policy m…

### DIFF
--- a/modules/aws_iam_policy/tf_module/main.tf
+++ b/modules/aws_iam_policy/tf_module/main.tf
@@ -1,3 +1,14 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  templatevars = {
+    account_id = data.aws_caller_identity.current.account_id
+    arn        = data.aws_caller_identity.current.arn
+    region     = data.aws_region.current.name
+  }
+}
+
 resource "random_string" "policy_suffix" {
   length  = 4
   special = false
@@ -6,7 +17,7 @@ resource "random_string" "policy_suffix" {
 
 resource "aws_iam_policy" "policy" {
   name   = "${var.env_name}-${var.layer_name}-${var.module_name}"
-  policy = file(var.file)
+  policy = templatefile(var.file, local.templatevars)
   tags = {
     "opta-created" : true
   }


### PR DESCRIPTION
# Description
The `aws_iam_policy` module accepts a file as an input. This requires hardcoding commonly used variables in IAM policies like the account ID or region directly into the contents of the file. However, these may need to be determined at runtime for certain configurations. This PR adds support for template interpolation of commonly used variables into the user-specified policy document:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "secretsmanager:GetSecretValue"
            ],
            "Resource": "arn:aws:secretsmanager:${region}:${account_id}:secret:*"
        }
    ]
}
```

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Smoke tested.
