### PR TITLE
Do not lookup NAT Gateways if we do not create the VPC

### DIFF
--- a/modules/aws_base/tf_module/existing_vpc.tf
+++ b/modules/aws_base/tf_module/existing_vpc.tf
@@ -19,7 +19,7 @@ data "aws_subnet" "private_subnets" {
 }
 
 data "aws_nat_gateway" "nat_gateways" {
-  for_each = data.aws_route.private_nat_routes
+  for_each = local.create_vpc ? toset([]) : data.aws_route.private_nat_routes
   id       = each.value.nat_gateway_id
   state    = "available"
 }


### PR DESCRIPTION
# Description
When `local.create_vpc` is set to `true`, we do not create the VPC in Opta.  We should avoid looking up information about NAT Gateways in this case as well.  We do wire this up as an output, but the output is also gated by `local.create_vpc`, so this shouldn't matter too much.

See https://github.com/unionai/opta/blob/main/modules/aws_base/tf_module/locals.tf#L7

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
I have not tested this yet.