### PR TITLE
Do not read NAT Gateway information when we do not create the VPC

### DIFF
--- a/modules/aws_base/tf_module/existing_vpc.tf
+++ b/modules/aws_base/tf_module/existing_vpc.tf
@@ -18,12 +18,6 @@ data "aws_subnet" "private_subnets" {
   state    = "available"
 }
 
-data "aws_nat_gateway" "nat_gateways" {
-  for_each = local.create_vpc ? toset([]) : toset(data.aws_route.private_nat_routes)
-  id       = each.value.nat_gateway_id
-  state    = "available"
-}
-
 data "aws_route_table" "private_subnet_routes" {
   for_each  = data.aws_subnet.private_subnets
   subnet_id = each.value.id

--- a/modules/aws_base/tf_module/locals.tf
+++ b/modules/aws_base/tf_module/locals.tf
@@ -4,5 +4,5 @@ locals {
   vpc_cidr_blocks    = local.create_vpc ? [aws_vpc.vpc[0].cidr_block] : data.aws_vpc.vpc[0].cidr_block_associations[*].cidr_block
   private_subnet_ids = local.create_vpc ? aws_subnet.private_subnets[*].id : values(data.aws_subnet.private_subnets)[*].id
   public_subnet_ids  = local.create_vpc ? aws_subnet.public_subnets[*].id : values(data.aws_subnet.public_subnets)[*].id
-  public_nat_ips     = local.create_vpc ? aws_eip.nat_eips[*].public_ip : values(data.aws_nat_gateway.nat_gateways)[*].public_ip
+  public_nat_ips     = local.create_vpc ? aws_eip.nat_eips[*].public_ip : []
 }


### PR DESCRIPTION
# Description
This may cause issues for the `mongodb` module, which may depend on having `public_nat_ips`.  At Union, we do not use this module so I'm not too worried about it.

This will default the `public_nat_ips` output to an empty list if we do not create the VPC through Opta.  I was able to get a successful `plan` with this change.

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
Ran a plan locally.
