### PR TITLE
Remove bugged global resource tags overrides

### DIFF
--- a/opta/commands/apply.py
+++ b/opta/commands/apply.py
@@ -19,7 +19,7 @@ from opta.core.aws import AWS
 from opta.core.azure import Azure
 from opta.core.cloud_client import CloudClient
 from opta.core.gcp import GCP
-from opta.core.generator import gen, gen_opta_resource_tags
+from opta.core.generator import gen
 from opta.core.helm_cloud_client import HelmCloudClient
 from opta.core.kubernetes import cluster_exist, tail_module_log, tail_namespace_events
 from opta.core.local import Local
@@ -169,7 +169,6 @@ def _apply(
             )
 
     Terraform.create_state_storage(layer)
-    gen_opta_resource_tags(layer)
     cloud_client: CloudClient
     if layer.cloud == "aws":
         cloud_client = AWS(layer)

--- a/opta/commands/generate_terraform.py
+++ b/opta/commands/generate_terraform.py
@@ -10,7 +10,7 @@ import click
 from opta.amplitude import amplitude_client
 from opta.commands.local_flag import _clean_folder, _clean_tf_folder
 from opta.constants import REGISTRY, TF_FILE_PATH, VERSION
-from opta.core.generator import gen, gen_opta_resource_tags
+from opta.core.generator import gen
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from opta.module import Module
@@ -139,9 +139,6 @@ def generate_terraform(
                     abort=True,
                 )
             _clean_folder(output_dir)
-
-        # to keep consistent with what opta does - we could make this an option if opta tags are not desirable
-        gen_opta_resource_tags(layer)
 
         # copy helm service dir
         if "k8s-service" in [m.type for m in layer.modules]:

--- a/opta/core/generator.py
+++ b/opta/core/generator.py
@@ -78,10 +78,3 @@ def gen(
         gen_tf.gen(ret, TF_FILE_PATH)
 
         yield module_idx, current_modules, total_module_count
-
-
-# Generate a tags override file in every module, that adds opta tags to every resource.
-def gen_opta_resource_tags(layer: "Layer") -> None:
-    if "aws" in layer.providers:
-        for module in layer.modules:
-            module.gen_tags_override()

--- a/opta/module.py
+++ b/opta/module.py
@@ -7,7 +7,6 @@ import hcl2
 from opta.constants import REGISTRY
 from opta.exceptions import UserErrors
 from opta.resource import Resource
-from opta.utils import deep_merge, json
 
 TAGS_OVERRIDE_FILE = "tags_override.tf.json"
 if TYPE_CHECKING:

--- a/opta/module.py
+++ b/opta/module.py
@@ -145,35 +145,6 @@ class Module:
 
         return module_blk
 
-    # Generate an override file in the module, that adds extra tags to every resource.
-    def gen_tags_override(self) -> None:
-        override_config: Any = {"resource": []}
-
-        resources = self.get_terraform_resources()
-        for resource in resources:
-            resource_tags_raw = resource.tf_config.get("tags", {})
-            resource_tags = {}
-            [resource_tags.update(tag) for tag in resource_tags_raw]
-
-            # Add additional tags to each AWS resource
-            resource_tags = deep_merge(
-                resource_tags,
-                {
-                    "opta": "true",
-                    "layer": self.layer_name,
-                    "tf_address": f"module.{self.name}.{resource.type}.{resource.name}",
-                },
-            )
-
-            override_config["resource"].append(
-                {resource.type: {resource.name: {"tags": resource_tags}}}
-            )
-        if override_config["resource"] == []:
-            return
-
-        with open(f"{self.module_dir_path}/{TAGS_OVERRIDE_FILE}", "w") as f:
-            json.dump(override_config, f, ensure_ascii=False, indent=2)
-
     def translate_location(self, loc: str) -> str:
         if loc == "":
             return ""

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -18,7 +18,6 @@ from opta.module import Module
 @fixture
 def basic_mocks(mocker: MockFixture) -> None:
     mocker.patch("opta.commands.apply.amplitude_client.send_event")
-    mocker.patch("opta.commands.apply.gen_opta_resource_tags")
     mocker.patch("opta.commands.apply.PlanDisplayer")
 
     # Mock remote state

--- a/tests/core/test_generator.py
+++ b/tests/core/test_generator.py
@@ -6,7 +6,7 @@ import yaml
 from pytest_mock import MockFixture
 
 from opta.constants import tf_modules_path
-from opta.core.generator import gen_all, gen_opta_resource_tags
+from opta.core.generator import gen_all
 from opta.exceptions import UserErrors
 from opta.layer import Layer
 from tests.fixtures.basic_apply import BASIC_APPLY
@@ -46,33 +46,3 @@ class TestGenerator:
             Layer.load_from_yaml("", None)
 
         os.remove(test_gen_file_path)
-
-    def test_gen_resource_tags(self, mocker: MockFixture) -> None:
-        gen_tags_file = "pytest-override.tf.json"
-        mocker.patch("opta.module.TAGS_OVERRIDE_FILE", gen_tags_file)
-        gen_tags_file_path = os.path.join(
-            tf_modules_path, "aws_base/tf_module", gen_tags_file
-        )
-
-        mocker.patch("opta.layer.open")
-        mocker.patch("opta.layer.os.path.exists")
-        mocker.patch("opta.layer.validate_yaml")
-
-        opta_config, gen_tf_file = BASIC_APPLY
-        opta_config = opta_config.copy()
-        mocker.patch("opta.layer.yaml.load", return_value=opta_config)
-        layer = Layer.load_from_yaml("", None)
-
-        gen_opta_resource_tags(layer)
-        with open(gen_tags_file_path) as f:
-            tags_config = json.load(f)
-
-        has_vpc = False
-        for resource in tags_config["resource"]:
-            resource_type = list(resource.keys())[0]
-            if resource_type == "aws_vpc":
-                has_vpc = True
-                assert resource[resource_type]["vpc"]["tags"]["opta"] == "true"
-
-        assert has_vpc
-        os.remove(gen_tags_file_path)

--- a/tests/core/test_generator.py
+++ b/tests/core/test_generator.py
@@ -5,7 +5,6 @@ import pytest
 import yaml
 from pytest_mock import MockFixture
 
-from opta.constants import tf_modules_path
 from opta.core.generator import gen_all
 from opta.exceptions import UserErrors
 from opta.layer import Layer


### PR DESCRIPTION
Tag overrides are applied at the terraform module level, instead of at the level of an instantiation of the terraform module. As such, the tag overrides set by the later opta modules in a layer will incorrectly override the values for all earlier opta modules.

Consider the following `opta.yaml`:
```
name: opta-debug
org_name: opta-debug
providers:
  aws:
    account_id: 111111111111
    region: us-east-2
modules:
  - type: base
  - type: k8s-cluster
    k8s_version: "1.24"
  - name: first
    type: aws-iam-role
    allowed_k8s_services:
      - namespace: "*"
        service_name: "*"
  - name: second
    type: aws-iam-role
    allowed_k8s_services:
      - namespace: "*"
        service_name: "*"
````

Running `opta generate-terraform` creates the following directory structure:
```
> tree gen-tf-opta-debug
gen-tf-opta-debug
├── data.tf.json
├── module-base.tf.json
├── module-first.tf.json
├── module-k8scluster.tf.json
├── module-second.tf.json
├── modules
│   ├── aws_base
│   │   └── tf_module
│   │       ├── cache_subnet.tf
│   │       ├── db_subnet.tf
│   │       ├── documentdb_subnet.tf
│   │       ├── ebs.tf
│   │       ├── existing_vpc.tf
│   │       ├── kms.tf
│   │       ├── locals.tf
│   │       ├── log_bucket.tf
│   │       ├── outputs.tf
│   │       ├── private_subnet.tf
│   │       ├── public_subnet.tf
│   │       ├── s3_gateway.tf
│   │       ├── security_groups.tf
│   │       ├── tags_override.tf.json
│   │       ├── variables.tf
│   │       └── vpc.tf
│   ├── aws_eks
│   │   └── tf_module
│   │       ├── default_node_group.tf
│   │       ├── eks.tf
│   │       ├── iam.tf
│   │       ├── openid.tf
│   │       ├── outputs.tf
│   │       ├── tags_override.tf.json
│   │       ├── thumbprint.sh
│   │       └── variables.tf
│   └── aws_iam_role
│       └── tf_module
│           ├── main.tf
│           ├── outputs.tf
│           ├── tags_override.tf.json
│           └── veriables.tf
├── output.tf.json
├── provider.tf.json
├── readme-opta-debug.html
└── terraform.tf.json

8 directories, 37 files
```

Notice that the `tags_override.tf.json` files exist within the respective `modules/*/tf_module` directories, and contain, for example:
```
> cat gen-tf-opta-debug/modules/aws_iam_role/tf_module/tags_override.tf.json
{
  "resource": [
    {
      "aws_iam_policy": {
        "vanilla_policy": {
          "tags": {
            "opta": "true",
            "layer": "opta-debug",
            "tf_address": "module.second.aws_iam_policy.vanilla_policy"
          }
        }
      }
    },
    {
      "aws_iam_role": {
        "role": {
          "tags": {
            "opta": "true",
            "layer": "opta-debug",
            "tf_address": "module.second.aws_iam_role.role"
          }
        }
      }
    },
    {
      "aws_iam_role_policy_attachment": {
        "vanilla_role_attachment": {
          "tags": {
            "opta": "true",
            "layer": "opta-debug",
            "tf_address": "module.second.aws_iam_role_policy_attachment.vanilla_role_attachment"
          }
        }
      }
    },
    {
      "aws_iam_role_policy_attachment": {
        "extra_policies_attachment": {
          "tags": {
            "opta": "true",
            "layer": "opta-debug",
            "tf_address": "module.second.aws_iam_role_policy_attachment.extra_policies_attachment"
          }
        }
      }
    },
    {
      "aws_iam_role_policy": {
        "pass_role_to_self": {
          "tags": {
            "opta": "true",
            "layer": "opta-debug",
            "tf_address": "module.second.aws_iam_role_policy.pass_role_to_self"
          }
        }
      }
    }
  ]
}%
```

The `tf_address` key contains the path to a specific module instance. In this case, it is the `second` iam role. Consequently, note that the `first` iam role incorrectly gets the `tf_address` of the `second` iam role in the `tags` and `tags_all` attributes:
```
> terraform plan -target=module.first.aws_iam_policy.vanilla_policy

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.first.aws_iam_policy.vanilla_policy will be created
  + resource "aws_iam_policy" "vanilla_policy" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "opta-debug-opta-debug-first"
      + path      = "/"
      + policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "iam:GetContextKeysForCustomPolicy",
                          + "iam:GetContextKeysForPrincipalPolicy",
                          + "iam:SimulateCustomPolicy",
                          + "iam:SimulatePrincipalPolicy",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "PolicySimulatorAPI"
                    },
                  + {
                      + Action   = [
                          + "iam:GetGroup",
                          + "iam:GetGroupPolicy",
                          + "iam:GetPolicy",
                          + "iam:GetPolicyVersion",
                          + "iam:GetRole",
                          + "iam:GetRolePolicy",
                          + "iam:GetUser",
                          + "iam:GetUserPolicy",
                          + "iam:ListAttachedGroupPolicies",
                          + "iam:ListAttachedRolePolicies",
                          + "iam:ListAttachedUserPolicies",
                          + "iam:ListGroups",
                          + "iam:ListGroupPolicies",
                          + "iam:ListGroupsForUser",
                          + "iam:ListRolePolicies",
                          + "iam:ListRoles",
                          + "iam:ListUserPolicies",
                          + "iam:ListUsers",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "PolicySimulatorConsole"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id = (known after apply)
      + tags      = {
          + "layer"      = "opta-debug"
          + "opta"       = "true"
          + "tf_address" = "module.second.aws_iam_policy.vanilla_policy"
        }
      + tags_all  = {
          + "layer"      = "opta-debug"
          + "opta"       = "true"
          + "tf_address" = "module.second.aws_iam_policy.vanilla_policy"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```