### PR TITLE
Clean up tags override files during every Opta run

### DIFF
--- a/opta/core/generator.py
+++ b/opta/core/generator.py
@@ -1,11 +1,12 @@
 from typing import TYPE_CHECKING, Generator, List, Optional, Tuple
-
 import click
 from colored import attr
+from pathlib import Path
 
 from opta import gen_tf
-from opta.constants import TF_FILE_PATH
+from opta.constants import TF_FILE_PATH, tf_modules_path
 from opta.core.kubernetes import cluster_exist, current_image_digest_tag, set_kube_config
+from opta.module import TAGS_OVERRIDE_FILE
 from opta.utils import deep_merge, logger
 
 if TYPE_CHECKING:
@@ -83,5 +84,9 @@ def gen(
 # Generate a tags override file in every module, that adds opta tags to every resource.
 def gen_opta_resource_tags(layer: "Layer") -> None:
     if "aws" in layer.providers:
+        # Remove all generated tags files, forcing re-generation
+        for tag_fn in Path(tf_modules_path).glob(f"**/{TAGS_OVERRIDE_FILE}"):
+            tag_fn.unlink()
+
         for module in layer.modules:
             module.gen_tags_override()

--- a/opta/module.py
+++ b/opta/module.py
@@ -1,6 +1,5 @@
 import os
 import re
-import glob
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple
 
 import hcl2
@@ -148,11 +147,6 @@ class Module:
 
     # Generate an override file in the module, that adds extra tags to every resource.
     def gen_tags_override(self) -> None:
-        # Clean up all tags_override.tf.json files, this ensures we do not
-        # leak tags to other environments/layers during future Opta runs.
-        for fn in glob.glob(f"{self.module_dir_path}/**/tf_module/{TAGS_OVERRIDE_FILE}"):
-            os.remove(fn)
-
         override_config: Any = {"resource": []}
 
         resources = self.get_terraform_resources()

--- a/opta/module.py
+++ b/opta/module.py
@@ -1,5 +1,6 @@
 import os
 import re
+import glob
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple
 
 import hcl2
@@ -147,6 +148,11 @@ class Module:
 
     # Generate an override file in the module, that adds extra tags to every resource.
     def gen_tags_override(self) -> None:
+        # Clean up all tags_override.tf.json files, this ensures we do not
+        # leak tags to other environments/layers during future Opta runs.
+        for fn in glob.glob(f"{self.module_dir_path}/**/tf_module/{TAGS_OVERRIDE_FILE}"):
+            os.remove(fn)
+
         override_config: Any = {"resource": []}
 
         resources = self.get_terraform_resources()


### PR DESCRIPTION
# Description
Opta is currently generating tags and applying them to resources it manages.  It does this by sticking a `tags_override.tf.json` file into each `~/.opta/module/{module}/tf_module` directory that it manages tags for.

Unfortunately, it does not remove this file after it is done.  This has caused some issues where we leak tags across different invocations of `opta`.

This is a bit of a hack, we should really clean this up _after_ the Opta run finishes, but I wanted to make sure we handle situations where Opta may crash while it is running.

Removing all `tags_override.tf.json` files before Opta generates tags again seems like the safest bet to me.

# Safety checklist
* [x] This change is backwards compatible and safe to apply by existing users
* [x] This change will NOT lead to data loss
* [x] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
I tested this locally by setting some breakpoints and running Opta in a Python debugger.  I was able to verify that it correctly cleans up leftover `tags_override.tf.json` files between runs.