### PR TITLE
Update Github PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,3 @@
-# Description
+# DEPRECATED
 
-
-# Safety checklist
-* [ ] This change is backwards compatible and safe to apply by existing users
-* [ ] This change will NOT lead to data loss
-* [ ] This change will NOT lead to downtime who already has an env/service setup
-
-## How has this change been tested, beside unit tests?
-YOUR_ANSWER
+This repo is deprecated and no longer maintained.


### PR DESCRIPTION
# Description
Updates the PR template to indicate this repository is deprecated.  Should hopefully remind people not to merge things here until we feel comfortable archiving this repo.

Moving forward, for `unionai`-specific changes we will make these in our monorepo.
